### PR TITLE
Corrected arguments of method Pogs() in flat C interface .cpp file

### DIFF
--- a/src/cpu/pogs.cpp
+++ b/src/cpu/pogs.cpp
@@ -43,7 +43,7 @@ Pogs<T, M, P>::Pogs(const M &A)
       _de(0), _z(0), _zt(0),
       _rho(static_cast<T>(kRhoInit)),
       _done_init(false),
-      _x(0), _y(0), _mu(0), _lambda(0), _optval(static_cast<T>(0.)),
+      _x(0), _y(0), _mu(0), _lambda(0), _optval(static_cast<T>(0.)), _final_iter(0),
       _abs_tol(static_cast<T>(kAbsTol)),
       _rel_tol(static_cast<T>(kRelTol)),
       _max_iter(kMaxIter),
@@ -267,8 +267,10 @@ PogsStatus Pogs<T, M, P>::Solve(const std::vector<FunctionObj<T> > &f,
     }
 
     // Break if converged or there are nans
-    if (converged || k == _max_iter - 1)
+    if (converged || k == _max_iter - 1){
+      _final_iter = k;
       break;
+    }
 
     // Update dual variable.
     gsl::blas_axpy(kAlpha, &z12, &zt);

--- a/src/gpu/pogs.cu
+++ b/src/gpu/pogs.cu
@@ -46,7 +46,7 @@ Pogs<T, M, P>::Pogs(const M &A)
       _de(0), _z(0), _zt(0),
       _rho(static_cast<T>(kRhoInit)),
       _done_init(false),
-      _x(0), _y(0), _mu(0), _lambda(0), _optval(static_cast<T>(0.)),
+      _x(0), _y(0), _mu(0), _lambda(0), _optval(static_cast<T>(0.)), _final_iter(0),
       _abs_tol(static_cast<T>(kAbsTol)),
       _rel_tol(static_cast<T>(kRelTol)),
       _max_iter(kMaxIter),
@@ -295,8 +295,10 @@ PogsStatus Pogs<T, M, P>::Solve(const std::vector<FunctionObj<T> > &f,
     }
 
     // Break if converged or there are nans
-    if (converged || k == _max_iter - 1)// || cml::vector_any_isnan(&zt))
+    if (converged || k == _max_iter - 1){ // || cml::vector_any_isnan(&zt))
+      _final_iter = k;
       break;
+    }
 
     // Update dual variable.
     cml::blas_axpy(hdl, kAlpha, &z12, &zt);

--- a/src/include/pogs.h
+++ b/src/include/pogs.h
@@ -32,6 +32,7 @@ enum PogsStatus { POGS_SUCCESS,    // Converged succesfully.
                   POGS_NAN_FOUND,  // Encountered nan.
                   POGS_ERROR };    // Generic error, check logs.
 
+
 // Proximal Operator Graph Solver.
 template <typename T, typename M, typename P>
 class Pogs {
@@ -47,6 +48,7 @@ class Pogs {
 
   // Output.
   T *_x, *_y, *_mu, *_lambda, _optval;
+  unsigned int _final_iter;
 
   // Parameters.
   T _abs_tol, _rel_tol;
@@ -68,6 +70,7 @@ class Pogs {
   const T*     GetLambda()      const { return _lambda; }
   const T*     GetMu()          const { return _mu; }
   T            GetOptval()      const { return _optval; }
+  unsigned int GetFinalIter()   const { return _final_iter; }
   T            GetRho()         const { return _rho; }
   T            GetRelTol()      const { return _rel_tol; }
   T            GetAbsTol()      const { return _abs_tol; }
@@ -76,6 +79,7 @@ class Pogs {
   unsigned int GetVerbose()     const { return _verbose; }
   bool         GetAdaptiveRho() const { return _adaptive_rho; }
   bool         GetGapStop()     const { return _gap_stop; }
+
 
   // Setters for parameters and initial values.
   void SetRho(T rho)                       { _rho = rho; }

--- a/src/interface_c/pogs_c.cpp
+++ b/src/interface_c/pogs_c.cpp
@@ -8,7 +8,7 @@ int Pogs(size_t m, size_t n, const T *A,
          const T *f_a, const T *f_b, const T *f_c, const T *f_d, const T *f_e, const FUNCTION *f_h,
          const T *g_a, const T *g_b, const T *g_c, const T *g_d, const T *g_e, const FUNCTION *g_h,
          T rho, T abs_tol, T rel_tol, unsigned int max_iter, unsigned int verbose,
-         bool adaptive_rho, bool gap_stop, T *x, T *y, T *l, T *optval) {
+         bool adaptive_rho, bool gap_stop, T *x, T *y, T *l, T *optval, unsigned int * final_iter) {
   // Create pogs struct.
   char ord = O == ROW_MAJ ? 'r' : 'c';
   pogs::MatrixDense<T> A_(ord, m, n, A);
@@ -40,6 +40,7 @@ int Pogs(size_t m, size_t n, const T *A,
   // Solve.
   int err = pogs_data.Solve(f, g);
   *optval = pogs_data.GetOptval();
+  *final_iter = pogs_data.GetFinalIter();
 
   memcpy(x, pogs_data.GetX(), n);
   memcpy(y, pogs_data.GetY(), m);
@@ -56,7 +57,7 @@ int PogsD(enum ORD ord, size_t m, size_t n, const double *A,
           const double *g_d, const double *g_e, const enum FUNCTION *g_h,
           double rho, double abs_tol, double rel_tol, unsigned int max_iter,
           unsigned int verbose, int adaptive_rho, int gap_stop,
-          double *x, double *y, double *l, double *optval) {
+          double *x, double *y, double *l, double *optval, unsigned int * final_iter) {
   if (ord == COL_MAJ) {
     return Pogs<double, COL_MAJ>(m, n, A, f_a, f_b, f_c, f_d, f_e, f_h,
         g_a, g_b, g_c, g_d, g_e, g_h, rho, abs_tol, rel_tol, max_iter,
@@ -77,7 +78,7 @@ int PogsS(enum ORD ord, size_t m, size_t n, const float *A,
           const float *g_d, const float *g_e, const enum FUNCTION *g_h,
           float rho, float abs_tol, float rel_tol, unsigned int max_iter,
           unsigned int verbose, int adaptive_rho, int gap_stop,
-          float *x, float *y, float *l, float *optval) {
+          float *x, float *y, float *l, float *optval, unsigned int * final_iter) {
   if (ord == COL_MAJ) {
     return Pogs<float, COL_MAJ>(m, n, A, f_a, f_b, f_c, f_d, f_e, f_h,
         g_a, g_b, g_c, g_d, g_e, g_h, rho, abs_tol, rel_tol, max_iter,

--- a/src/interface_c/pogs_c.cpp
+++ b/src/interface_c/pogs_c.cpp
@@ -4,10 +4,10 @@
 #include "pogs_c.h"
 
 template <typename T, ORD O>
-int Pogs(size_t m, size_t n, T *A,
-         T *f_a, T *f_b, T *f_c, T *f_d, T *f_e, FUNCTION *f_h,
-         T *g_a, T *g_b, T *g_c, T *g_d, T *g_e, FUNCTION *g_h,
-         T rho, T abs_tol, T rel_tol, unsigned int max_iter, int verbose,
+int Pogs(size_t m, size_t n, const T *A,
+         const T *f_a, const T *f_b, const T *f_c, const T *f_d, const T *f_e, const FUNCTION *f_h,
+         const T *g_a, const T *g_b, const T *g_c, const T *g_d, const T *g_e, const FUNCTION *g_h,
+         T rho, T abs_tol, T rel_tol, unsigned int max_iter, unsigned int verbose,
          bool adaptive_rho, bool gap_stop, T *x, T *y, T *l, T *optval) {
   // Create pogs struct.
   char ord = O == ROW_MAJ ? 'r' : 'c';
@@ -55,7 +55,7 @@ int PogsD(enum ORD ord, size_t m, size_t n, const double *A,
           const double *g_a, const double *g_b, const double *g_c,
           const double *g_d, const double *g_e, const enum FUNCTION *g_h,
           double rho, double abs_tol, double rel_tol, unsigned int max_iter,
-          int verbose, int adaptive_rho, int gap_stop,
+          unsigned int verbose, int adaptive_rho, int gap_stop,
           double *x, double *y, double *l, double *optval) {
   if (ord == COL_MAJ) {
     return Pogs<double, COL_MAJ>(m, n, A, f_a, f_b, f_c, f_d, f_e, f_h,
@@ -76,7 +76,7 @@ int PogsS(enum ORD ord, size_t m, size_t n, const float *A,
           const float *g_a, const float *g_b, const float *g_c,
           const float *g_d, const float *g_e, const enum FUNCTION *g_h,
           float rho, float abs_tol, float rel_tol, unsigned int max_iter,
-          int verbose, int adaptive_rho, int gap_stop,
+          unsigned int verbose, int adaptive_rho, int gap_stop,
           float *x, float *y, float *l, float *optval) {
   if (ord == COL_MAJ) {
     return Pogs<float, COL_MAJ>(m, n, A, f_a, f_b, f_c, f_d, f_e, f_h,

--- a/src/interface_c/pogs_c.h
+++ b/src/interface_c/pogs_c.h
@@ -67,7 +67,7 @@ int PogsD(enum ORD ord, size_t m, size_t n, const double *A,
           const double *g_a, const double *g_b, const double *g_c,
           const double *g_d, const double *g_e, const enum FUNCTION *g_h,
           double rho, double abs_tol, double rel_tol, unsigned int max_iter,
-          int verbose, int adaptive_rho, int gap_stop,
+          unsigned int verbose, int adaptive_rho, int gap_stop,
           double *x, double *y, double *l, double *optval);
 
 int PogsS(enum ORD ord, size_t m, size_t n, const float *A,
@@ -76,7 +76,7 @@ int PogsS(enum ORD ord, size_t m, size_t n, const float *A,
           const float *g_a, const float *g_b, const float *g_c,
           const float *g_d, const float *g_e, const enum FUNCTION *g_h,
           float rho, float abs_tol, float rel_tol, unsigned int max_iter,
-          int verbose, int adaptive_rho, int gap_stop,
+          unsigned int verbose, int adaptive_rho, int gap_stop,
           float *x, float *y, float *l, float *optval);
 
 // TODO: Add interface for sparse version.

--- a/src/interface_c/pogs_c.h
+++ b/src/interface_c/pogs_c.h
@@ -68,7 +68,7 @@ int PogsD(enum ORD ord, size_t m, size_t n, const double *A,
           const double *g_d, const double *g_e, const enum FUNCTION *g_h,
           double rho, double abs_tol, double rel_tol, unsigned int max_iter,
           unsigned int verbose, int adaptive_rho, int gap_stop,
-          double *x, double *y, double *l, double *optval);
+          double *x, double *y, double *l, double *optval, unsigned int * final_iter);
 
 int PogsS(enum ORD ord, size_t m, size_t n, const float *A,
           const float *f_a, const float *f_b, const float *f_c,
@@ -77,7 +77,7 @@ int PogsS(enum ORD ord, size_t m, size_t n, const float *A,
           const float *g_d, const float *g_e, const enum FUNCTION *g_h,
           float rho, float abs_tol, float rel_tol, unsigned int max_iter,
           unsigned int verbose, int adaptive_rho, int gap_stop,
-          float *x, float *y, float *l, float *optval);
+          float *x, float *y, float *l, float *optval, unsigned int * final_iter);
 
 // TODO: Add interface for sparse version.
 


### PR DESCRIPTION
c examples were not compiling.

Corrected method arguments to address compile errors (<code>const T *</code> rather than <code>T *</code> for matrix A and functions f,g) and warnings (option <code>verbose</code> is specified as an <code>unsigned int</code> in the C++ version).