### PR TITLE
Updating OSX Frameworks path

### DIFF
--- a/src/interface_r/pogs/src/config.mk
+++ b/src/interface_r/pogs/src/config.mk
@@ -29,7 +29,7 @@ ifeq ($(OS), Darwin)
         DEVICEOPTS := -m64
     endif
     CUDA_LIB := $(CUDA_HOME)/lib
-    R_FRAMEWORK := -F$(R_HOME)/.. -framework R
+    R_FRAMEWORK := -F/Library/Frameworks -framework R
     RPATH := -rpath $(CUDA_LIB)
 endif
 


### PR DESCRIPTION
Installation of R binaries requires building from source on R 4.0.0+. When I tried to install on my Mac (OSX 13.2.1, M1 chip, R 4.2.1), I encountered the following error:

```bash
$ R CMD INSTALL --build pogs
* installing to library ‘/Library/Frameworks/R.framework/Versions/4.2-arm64/Resources/library’
* installing *source* package ‘pogs’ ...
** using staged installation
** libs
** arch - 
mkdir -p build
mkdir -p build/cpu 
g++ -I include -Icpu/include cpu/pogs.cpp  -g -O3 -Wall -std=c++11 -fPIC    -DPOGS_SINGLE=0 -c -o build/cpu/pogs.o 
mkdir -p build/cpu/matrix 
g++ -Iinclude -Icpu/include cpu/matrix/matrix_sparse.cpp  -g -O3 -Wall -std=c++11 -fPIC    -DPOGS_SINGLE=0  -c -o build/cpu/matrix/matrix_sparse.o
g++ -Iinclude -Icpu/include cpu/matrix/matrix_dense.cpp  -g -O3 -Wall -std=c++11 -fPIC    -DPOGS_SINGLE=0  -c -o build/cpu/matrix/matrix_dense.o
mkdir -p build/cpu/projector 
g++ -Iinclude -Icpu/include cpu/projector/projector_cgls.cpp  -g -O3 -Wall -std=c++11 -fPIC    -DPOGS_SINGLE=0  -c -o build/cpu/projector/projector_cgls.o
g++ -Iinclude -Icpu/include cpu/projector/projector_direct_dense.cpp  -g -O3 -Wall -std=c++11 -fPIC    -DPOGS_SINGLE=0  -c -o build/cpu/projector/projector_direct_dense.o
ar cr build/pogs.a build/cpu/pogs.o build/cpu/matrix/matrix_sparse.o build/cpu/matrix/matrix_dense.o build/cpu/projector/projector_cgls.o build/cpu/projector/projector_direct_dense.o
g++ -Iinclude -I"/Library/Frameworks/R.framework/Resources/include"  -g -O3 -Wall -std=c++11 -fPIC    -DPOGS_SINGLE=0 pogs_r.cpp -c -o pogs_r.o
g++ -o pogs.so -shared pogs_r.o build/pogs.a \
	-rpath /usr/local/cuda/lib blas2cblas.cpp -L/Library/Frameworks/R.framework/Resources/lib -lRblas -F/Library/Frameworks/R.framework/Resources/.. -framework R  -g -O3 -Wall -std=c++11 -fPIC    -DPOGS_SINGLE=0
ld: framework not found R
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [pogs.so] Error 1
ERROR: compilation failed for package ‘pogs’
```

After applying this small commit, I can successfully build without this error and run the examples.